### PR TITLE
Adds different retry modes.

### DIFF
--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -107,7 +107,7 @@ open class BufferedOutput: Output {
     }
 
     open func write(_ chunk: Chunk, completion: @escaping (WriteResult) -> Void) {
-        completion(.success)
+        completion(.failureNonRetryable)
     }
 
     open var storageGroup: String {

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -7,14 +7,14 @@ private func makeLog() -> LogEntry {
 }
 
 class TestingBufferedOutput: BufferedOutput {
-    var shouldSuccess: Bool = true
+    var writeResult: WriteResult = .success
     fileprivate(set) var calledWriteCount: Int = 0
     var writeCallback: (() -> Void)?
     var waitUntilCurrentCompletionBlock: (() -> Void)?
 
-    override func write(_ chunk: BufferedOutput.Chunk, completion: @escaping (Bool) -> Void) {
+    override func write(_ chunk: BufferedOutput.Chunk, completion: @escaping (WriteResult) -> Void) {
         calledWriteCount += 1
-        completion(shouldSuccess)
+        completion(writeResult)
         writeCallback?()
     }
 
@@ -108,7 +108,7 @@ class BufferedOutputTests: XCTestCase {
     }
 
     func testRetryWhenFailed() {
-        output.shouldSuccess = false
+        output.writeResult = .failureRetryable
         output.configuration.logEntryCountLimit = 10
         output.configuration.retryLimit = 3
         XCTAssertEqual(output.calledWriteCount, 0)
@@ -187,11 +187,11 @@ class TestingBufferedOutputAsync: TestingBufferedOutput {
         return "pv_TestingBufferedOutput"
     }
 
-    override func write(_ chunk: BufferedOutput.Chunk, completion: @escaping (Bool) -> Void) {
+    override func write(_ chunk: BufferedOutput.Chunk, completion: @escaping (WriteResult) -> Void) {
         calledWriteCount += 1
         DispatchQueue.global().async {
             Thread.sleep(forTimeInterval: 0.1)
-            completion(self.shouldSuccess)
+            completion(self.writeResult)
             self.writeCallback?()
         }
     }
@@ -284,7 +284,7 @@ class BufferedOutputAsyncTests: XCTestCase {
     }
 
     func testRetryWhenFailed() {
-        output.shouldSuccess = false
+        output.writeResult = .failureRetryable
         output.configuration.logEntryCountLimit = 10
         output.configuration.retryLimit = 3
 


### PR DESCRIPTION
Be explicit about retry strategy when a write returns.

An use case would be when the network becomes unavailable. We should
suspend retries and the output until the next time we resume the
output (when the network resumes)

### Intended behavior and usage

When a chunk write fails due to unavailable internet connection, we will stop retrying. We will also drop the failed chunk from currentWritingChunks, allowing it to be re-flushed after we resume the output. We will make the following changes in the calling app:

* Suspend the output on app backgrounding: there is no need to continue the flush timer.
* Resume the output after network becomes available, AND after app foregrounding. The reason it needs to be an AND here is that if the network becomes available when the app is backgrounded, we’re not sure we’ll receive the notification. However, it’s okay to resume multiple times because currentWritingChunks are not re-added to the buffer to be flushed.
* Set retry count and intervals configurations to be shorter than they are now. Due to the changed mentioned, we reduce some unnecessary consumption of a chunk's retry limit. However, we cannot make these settings too low, because the connection could simply be bad for a long time without the phone being in airplane mode.

### Effects

We will not attempt to retry a chunk when the phone is in airplane mode or explicitly disconnected from the carrier.

If a disconnection is not detected, queued retries will be unaffected after app backgrounding (but will not execute while in background)

The downside is that, once the app returns to the foreground, the dropped chunks will immediately be re-created and retried, whereas previously they would wait until their next retry interval. If this causes a network crowding issue, we can explore staggering the requests.

#### App restart

Previously, chunks that exceeded their retry count will be attempted again after app restart (force quit). This will continue to be the case, with the addition that dropped chunks will also be retried.

Either way, this is dangerous because invalid entries will never clear out of the system if there is a programmer error. We should add a lifetime limit for each log entry, either by timestamp or by load count.