### PR TITLE
Add time-to-live limit for persisted log entries.

### DIFF
--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -177,11 +177,6 @@ open class BufferedOutput: Output {
         }
     }
 
-    private func pruneLogStorage() {
-        dispatchPrecondition(condition: .onQueue(readWriteQueue))
-
-    }
-
     private func flush() {
         dispatchPrecondition(condition: .onQueue(readWriteQueue))
 


### PR DESCRIPTION
If there is a programmer error, where a non-retryable error is treated
as a retryable error, the entry would never be deleted from disk and
would be retried each time the app restarts.

This patch adds a limit based on the number of seconds after
entry creation. After which the entry is dropped.

Also add tests.